### PR TITLE
Adicionar comando "run" para execução de comandos via arquivo/pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,36 @@ drwxr-xr-x  3 user user 4096 Sep 11 10:30 .
 - `exit` - Sair do shell
 - `clear` - Limpar a tela
 
+### Utilizando o runner
+
+O subcomando `run` permite executar comandos ou enviar dados para o dispositivo serial a partir de arquivos de texto ou da entrada padrão (stdin), facilitando automações e execuções em lote.
+
+```bash
+# Um só arquivo
+serial-cli run comandos.txt 
+
+# Ou múltiplos arquivos:
+serial-cli run comandos1.txt comandos2.txt
+
+# Com pipe operator
+cat comandos.txt | serial-cli run
+
+echo "send AT+GMR" | serial-cli run
+```
+
+#### Exemplo de arquivo de comandos
+
+Você pode criar um arquivo de texto (por exemplo, `comandos.txt`) com uma sequência de comandos para serem enviados ao dispositivo serial. No Serial CLI, o prefixo `!` executa comandos do sistema, e a sintaxe `!(comando)` é equivalente ao uso de `$()` no bash, ou seja, executa o comando e insere sua saída.
+
+Exemplo de conteúdo para `comandos.txt`:
+
+```bash
+send Olá, dispositivo! # envia o texto diretamente pela serial.
+!ls /dev/ttyUSB* # executa o comando no sistema e mostra a saída.
+!echo Teste direto do sistema # executa outro comando do sistema.
+send !(date) # executa o comando `date` no sistema e envia o resultado pela serial.
+```
+
 ### Recursos visuais
 - **Valores hexadecimais** são destacados em amarelo (ex: `0x41`, `0xFF`)
 - **Estatísticas** de transmissão são exibidas em ciano
@@ -135,13 +165,7 @@ serial_cli/
 ├── __init__.py
 ├── __main__.py          # Ponto de entrada como módulo
 ├── cli.py               # Interface de linha de comando
-└── __pycache__/
-```
-
-### Executar testes
-
-```bash
-pytest
+└── core.py              # Lógica principal do Serial CLI
 ```
 
 ### Contribuindo

--- a/serial_cli/cli.py
+++ b/serial_cli/cli.py
@@ -46,3 +46,38 @@ def shell(port: str, baudrate: int, timeout: int):
     """Start an interactive shell session."""
     with SerialCLI(port, baudrate, timeout=timeout) as serial:
         serial.shell()
+
+
+@main.command()
+@click.option(
+    "-b",
+    "--baudrate",
+    default=9600,
+    type=click.INT,
+    help="Set the baudrate for serial communication",
+)
+@click.option(
+    "-p",
+    "--port",
+    default=("/dev/ttyUSB0" if os.name != "nt" else "COM3"),
+    type=click.Path(exists=True) if os.name != "nt" else click.STRING,
+    help="Set the serial port to use",
+)
+@click.option(
+    "--timeout",
+    default=5,
+    type=click.INT,
+    help="Set the timeout for serial communication",
+)
+@click.argument("files", nargs=-1, type=click.Path(exists=True))
+def run(files: list[str], port: str, baudrate: int, timeout: int):
+    """Start an interactive shell session."""
+    import fileinput
+
+    with SerialCLI(port, baudrate, timeout=timeout) as serial:
+        try:
+            with fileinput.input(files=files) as file:
+                for line in file:
+                    serial.exec(line)
+        except Exception as e:
+            serial.console.print(str(e), style="bold red")

--- a/serial_cli/cli.py
+++ b/serial_cli/cli.py
@@ -1,11 +1,11 @@
 """Command Line Interface for serial communication."""
 
 import os
-import re
 
 import rich_click as click
 
 import serial_cli
+from serial_cli.core import SerialCLI
 
 click.rich_click.USE_RICH_MARKUP = True
 click.rich_click.USE_MARKDOWN = True
@@ -21,6 +21,7 @@ def main():
     """Serial CLI Tool"""
 
 
+@main.command()
 @click.option(
     "-b",
     "--baudrate",
@@ -32,7 +33,7 @@ def main():
     "-p",
     "--port",
     default=("/dev/ttyUSB0" if os.name != "nt" else "COM3"),
-    type=click.STRING,
+    type=click.Path(exists=True) if os.name != "nt" else click.STRING,
     help="Set the serial port to use",
 )
 @click.option(
@@ -41,73 +42,7 @@ def main():
     type=click.INT,
     help="Set the timeout for serial communication",
 )
-@main.command()
-def shell(port, baudrate, timeout):
+def shell(port: str, baudrate: int, timeout: int):
     """Start an interactive shell session."""
-    import subprocess
-
-    from rich.console import Console
-    from rich.text import Text
-    from serial import Serial
-
-    with Serial(port, baudrate, timeout=timeout) as serial:
-        click.echo(f"Connected to {port} at {baudrate} baud.")
-
-        console = Console()
-
-        while True:
-            prompt_text = Text(f"{port}> ", style="bold green")
-            stdin = console.input(prompt_text)
-
-            match stdin.lower():
-                case "exit":
-                    break
-                case "clear":
-                    console.clear()
-                    continue
-
-            try:
-                # Check if this is a command for the terminal or text to send over serial
-                if stdin.strip().startswith("!"):
-                    # Terminal command (starts with !)
-                    command = stdin[1:].strip()
-
-                    result = subprocess.run(
-                        command,
-                        shell=True,
-                        capture_output=True,
-                        text=True,
-                        check=True,
-                    )
-                    console.print(result.stdout, style="white")
-                    if result.stderr:
-                        console.print(result.stderr, style="red")
-                    continue
-
-                # Send expanded text over serial
-                serial.write((stdin + "\n").encode())
-
-                received = serial.read_until(b"\n\n")
-                # Highlight hex values in the response
-                highlighted_line = re.sub(
-                    r"(0x[0-9A-Fa-f]{2})",
-                    r"[bold yellow]\1[/bold yellow]",
-                    received.decode().strip(),
-                )
-                console.print(highlighted_line, style="white")
-
-                console.print(
-                    f"Sent: {len(stdin.encode())}b, Received: {len(received)}b",
-                    style="cyan",
-                )
-
-            except subprocess.CalledProcessError as e:
-                console.print(f"Error: {e.stderr}", style="red")
-            except FileNotFoundError:
-                console.print(
-                    f"[bold red]Command not found:[/bold red] {stdin}"
-                )
-            except Exception as e:
-                console.print(
-                    f"[bold red]An unexpected error occurred:[/bold red] {e}"
-                )
+    with SerialCLI(port, baudrate, timeout=timeout) as serial:
+        serial.shell()

--- a/serial_cli/core.py
+++ b/serial_cli/core.py
@@ -112,6 +112,16 @@ class SerialCLI(Serial):
                     f"[bold red]An unexpected error occurred:[/bold red] {e}"
                 )
 
+    def exec(self, line: str):
+        match line.lower():
+            case line if line.startswith("!"):
+                sp = self._run_subcommand(line[1:].strip())
+                if sp.returncode > 0:
+                    raise RuntimeError(f"Command fail: {line}")
+
+            case line if line.startswith("send "):
+                return self.send(line.removeprefix("send "))
+
     def send(self, text: str):
         subcommand_pattern = re.compile(r"!\(([^)]+)\)")
 

--- a/serial_cli/core.py
+++ b/serial_cli/core.py
@@ -1,0 +1,128 @@
+import re
+import subprocess
+
+from rich.console import Console
+from rich.text import Text
+from serial import Serial
+
+
+class SerialCLI(Serial):
+    console: Console
+
+    def __init__(
+        self,
+        port=None,
+        baudrate=9600,
+        bytesize=8,
+        parity="N",
+        stopbits=1,
+        timeout=None,
+        xonxoff=False,
+        rtscts=False,
+        write_timeout=None,
+        dsrdtr=False,
+        inter_byte_timeout=None,
+        exclusive=None,
+    ):
+        super().__init__(
+            port,
+            baudrate,
+            bytesize,
+            parity,
+            stopbits,
+            timeout,
+            xonxoff,
+            rtscts,
+            write_timeout,
+            dsrdtr,
+            inter_byte_timeout,
+            exclusive,
+        )
+        self.console = Console()
+        self.console.print(
+            f"[green]Connected to {port} at {baudrate} baud.[green]"
+        )
+
+    def _sanitize_output(self, received: bytes) -> str:
+        return re.sub(
+            r"(0x[0-9A-Fa-f]{2})",
+            r"[bold yellow]\1[/bold yellow]",
+            received.decode().strip(),
+        )
+
+    def _run_subcommand(self, cmd: str, print_output=True):
+        result = subprocess.run(
+            cmd,
+            shell=True,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        if print_output:
+            self.console.print(result.stdout, style="white")
+
+        if result.stderr:
+            self.console.print(result.stderr, style="red")
+
+        return result
+
+    def shell(self):
+        while True:
+            prompt_text = Text(f"{super().port}> ", style="bold green")
+            stdin = self.console.input(prompt_text)
+
+            match stdin.lower():
+                case "exit":
+                    break
+                case "clear":
+                    self.console.clear()
+                    continue
+
+            try:
+                # Check if this is a command for the terminal or text to send over serial
+                if stdin.strip().startswith("!"):
+                    # Terminal command (starts with !)
+                    command = stdin[1:].strip()
+                    self._run_subcommand(command)
+                    continue
+
+                # Send expanded text over serial
+                bytes_sent = self.send((stdin + "\n"))
+
+                # read all until receive \n\n or timeout
+                received = self.read_until(b"\n\n")
+
+                self.console.print(
+                    self._sanitize_output(received), style="white"
+                )
+
+                self.console.print(
+                    f"Sent: {bytes_sent}b, Received: {len(received)}b",
+                    style="cyan",
+                )
+
+            except subprocess.CalledProcessError as e:
+                self.console.print(f"Error: {e.stderr}", style="red")
+            except FileNotFoundError:
+                self.console.print(
+                    f"[bold red]Command not found:[/bold red] {stdin}"
+                )
+            except Exception as e:
+                self.console.print(
+                    f"[bold red]An unexpected error occurred:[/bold red] {e}"
+                )
+
+    def send(self, text: str):
+        subcommand_pattern = re.compile(r"!\(([^)]+)\)")
+
+        for subcommand in subcommand_pattern.findall(text):
+            sp = self._run_subcommand(subcommand, print_output=False)
+            if sp.returncode > 0:
+                raise RuntimeError(f"Command fail: {subcommand}")
+
+            text = re.sub(f"!\\({subcommand}\\)", sp.stdout, text, 1)
+
+        output = text.encode()
+        self.writelines(output.splitlines(True))
+
+        return len(output)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <3.13"
 resolution-markers = [
     "python_full_version >= '3.11'",


### PR DESCRIPTION
- Foi implementado o novo comando "run" na CLI, permitindo que os usuários enviem comandos para o dispositivo serial via arquivos de texto ou utilizando pipe operator.
- No arquivo README.md, foram adicionadas instruções e exemplos de uso para o comando "run", incluindo exemplos com arquivo de comandos e uso do operador pipe.
- No arquivo cli.py, foi criada a função de comando "run" com opções para definir porta, baudrate, timeout e aceitação de múltiplos arquivos como entrada.
- No arquivo core.py, adicionamos o método "exec" à classe SerialCLI para processar linhas de entrada, tratanto comandos do sistema (prefixados por "!") e comandos de envio (prefixados por "send "), além da substituição de expressões na forma “!(comando)” para imitar o comportamento do bash $(comando).

Essas mudanças possibilitam maior flexibilidade na automação e controle do dispositivo via comandos serial.